### PR TITLE
BUG 25:  LoadJumpSelection now cycles through all characters for Comp…

### DIFF
--- a/JumpchainCharacterBuilder/ListValidationClass.cs
+++ b/JumpchainCharacterBuilder/ListValidationClass.cs
@@ -82,7 +82,8 @@ namespace JumpchainCharacterBuilder
 
             foreach (CompanionPurchase companionPurchase in jumpBuild.CompanionPurchase)
             {
-                if (companionPurchase.CompanionImportDetails.Count < saveFile.CharacterList.Count)
+                // Since Companion Import Details doesn't have the jumper there should be one less character in that list.
+                if (companionPurchase.CompanionImportDetails.Count < saveFile.CharacterList.Count - 1)
                 {
                     int index = companionPurchase.CompanionImportDetails.Count;
                     for (int i = index; i < saveFile.CharacterList.Count - 1; i++)

--- a/JumpchainCharacterBuilder/ViewModel/JumpchainOverviewViewModel.cs
+++ b/JumpchainCharacterBuilder/ViewModel/JumpchainOverviewViewModel.cs
@@ -1429,6 +1429,11 @@ namespace JumpchainCharacterBuilder.ViewModel
             LoadWarehouseInvestment();
             LoadBodyModInvestment();
 
+            for (int characterIndex = 0; characterIndex < CharacterList.Count; characterIndex++)
+            {
+                ListValidationClass.CheckImportListCount(LoadedSave, JumpSelection, characterIndex);
+            }
+
             CharacterSelectionIndex = 0;
 
             OriginDiscountsSelection = JumpSelection.OriginDiscounts;


### PR DESCRIPTION
BUG 25:  LoadJumpSelection now cycles through all characters for CompanionImport validation

There was a scenario where viewing a character in a jump build would cause handled exceptions, (which would have some issues, like keeping origins from the previous viewed character), but then attempting to add an actual perk would cause the app to crash.

This would happen if:

1.  You had a Companion (say Abby) make their own Companion import on that jump
2.  Then created a new Character (say Zach) after that.
3.  Loading the jump after adding Zach would catch the new character and add Zach to all of Jumper's Companion Import options, but not Abby's.
4. Then viewing Zach (and especially creating a build purchase) would lead to trying to calculate Zach's stipend, which would include cycling through Abby's Companion Import list which did not have Zach present, leading to an index out of bounds exception.

(Viewing Abby specifically would cause her Companion Import list to update, but if Abby was never viewed then Zach's build would always have issues.)

In order to resolve this I have added a section to LoadJumpSelection after the objects are loaded to cycle through the CompanionImports of that jump for all characters in order to catch this sort of situation.

Additionally while debugging this I saw that CheckImportListCount was always cycling through the entire character list, attempting to look for new characters to add (that didn't really exist), because of an off-by-one in the check.

